### PR TITLE
Update to rescript v12.0.0-beta.4

### DIFF
--- a/.github/workflows/github-action-acceptance.yaml
+++ b/.github/workflows/github-action-acceptance.yaml
@@ -24,5 +24,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn
-      - run: yarn rescript:build
+      - run: yarn rescript:build:dev
       - run: yarn test

--- a/__tests__/expect_vitest.res
+++ b/__tests__/expect_vitest.res
@@ -22,14 +22,14 @@ let () = {
     test("toHaveLength", () => expect(["a", "b", "c"])->toHaveLength(3))
     test("toEqual", () => expect(1 + 2)->toEqual(3))
     test("toMatch", () => expect("banana")->toMatch("nana"))
-    test("toMatchRe", () => expect("banana")->toMatchRe(%re("/ana/")))
+    test("toMatchRe", () => expect("banana")->toMatchRe(/ana/))
     test("toThrow", () => expect(() => assert(false))->toThrow)
 
     test("toMatchInlineSnapshot", () => expect("foo")->toMatchInlineSnapshot("\"foo\""))
     test("toMatchSnapshot", () => expect("foo")->toMatchSnapshot)
     test("toMatchSnapshotWithName", () => expect("foo")->toMatchSnapshotWithName("bar"))
     test("toThrowErrorMatchingSnapshot", () =>
-      expect(() => Js.Exn.raiseError("foo error"))->toThrowErrorMatchingSnapshot
+      expect(() => JsError.throwWithMessage("foo error"))->toThrowErrorMatchingSnapshot
     )
 
     test("not toBe", () => expect(1 + 2)->not_->toBe(4))
@@ -48,31 +48,31 @@ let () = {
     test("not toHaveLength", () => expect(["a", "b", "c"])->not_->toHaveLength(2))
     test("not toEqual", () => expect(1 + 2)->not_->toEqual(4))
     test("not toMatch", () => expect("banana")->not_->toMatch("nanan"))
-    test("not toMatchRe", () => expect("banana")->not_->toMatchRe(%re("/anas/")))
+    test("not toMatchRe", () => expect("banana")->not_->toMatchRe(/anas/))
     test("not toThrow", () => expect(() => 2)->not_->toThrow)
 
-    test("expectFn", () => expectFn(raise, Invalid_argument("foo"))->toThrow)
+    test("expectFn", () => expectFn(throw, Invalid_argument("foo"))->toThrow)
   })
 
-  describe("Expect.Operators", () => {
-    open Expect
-    open! Expect.Operators
+  // describe("Expect.Operators", () => {
+  //   open Expect
+  //   open! Expect.Operators
 
-    test("==", () => expect(1 + 2) === 3)
-    test(">", () => expect(4) > 3)
-    test(">=", () => expect(4) >= 4)
-    test("<", () => expect(4) < 5)
-    test("<=", () => expect(4) <= 4)
-    test("=", () => expect(1 + 2) == 3)
-    test("<>", () => expect(1 + 2) != 4)
-    test("!=", () => expect(1 + 2) !== 4)
-  })
+  //   test("==", () => expect(1 + 2) === 3)
+  //   test(">", () => expect(4) > 3)
+  //   test(">=", () => expect(4) >= 4)
+  //   test("<", () => expect(4) < 5)
+  //   test("<=", () => expect(4) <= 4)
+  //   test("=", () => expect(1 + 2) == 3)
+  //   test("<>", () => expect(1 + 2) != 4)
+  //   test("!=", () => expect(1 + 2) !== 4)
+  // })
 
   describe("ExpectJs", () => {
     open ExpectJs
 
     test("toBeDefined", () => expect(Js.Undefined.return(3))->toBeDefined)
-    test("toBeFalsy", () => expect(nan)->toBeFalsy)
+    test("toBeFalsy", () => expect(Js.Float._NaN)->toBeFalsy)
     test("toBeNull", () => expect(Js.null)->toBeNull)
     test("toBeTruthy", () => expect([])->toBeTruthy)
     test("toBeUndefined", () => expect(Js.Undefined.empty)->toBeUndefined)
@@ -84,7 +84,7 @@ let () = {
     test("not toBeDefined", () => expect(Js.undefined)->not_->toBeDefined)
     test("not toBeFalsy", () => expect([])->not_->toBeFalsy)
     test("not toBeNull", () => expect(Js.Null.return(4))->not_->toBeNull)
-    test("not toBeTruthy", () => expect(nan)->not_->toBeTruthy)
+    test("not toBeTruthy", () => expect(Js.Float._NaN)->not_->toBeTruthy)
     test("not toBeUndefined", () => expect(Js.Undefined.return(4))->not_->toBeUndefined)
     test("not toContainProperties", () =>
       expect({"foo": 0, "bar": true})->not_->toContainProperties(["foo", "zoo"])

--- a/__tests__/mockjs_vitest.res
+++ b/__tests__/mockjs_vitest.res
@@ -104,7 +104,7 @@ let _ = {
       let fn = MockJs.fn(mockFn)
 
       let before = call(fn, 10)
-      mockFn->MockJs.mockImplementation(a => Js.Undefined.return(string_of_int(a)))->ignore
+      mockFn->MockJs.mockImplementation(a => Js.Undefined.return(Int.toString(a)))->ignore
 
       expect((before, call(fn, 18), call(fn, 24)))->toEqual((
         Js.Undefined.empty,
@@ -118,9 +118,9 @@ let _ = {
       let fn = MockJs.fn(mockFn)
 
       let before = call(fn, 10)
-      mockFn->MockJs.mockImplementationOnce(a => Js.Undefined.return(string_of_int(a)))->ignore
+      mockFn->MockJs.mockImplementationOnce(a => Js.Undefined.return(Int.toString(a)))->ignore
       mockFn
-      ->MockJs.mockImplementationOnce(a => Js.Undefined.return(string_of_int(a * 2)))
+      ->MockJs.mockImplementationOnce(a => Js.Undefined.return(Int.toString(a * 2)))
       ->ignore
 
       expect((before, call(fn, 18), call(fn, 24), call(fn, 12)))->toEqual((
@@ -178,7 +178,7 @@ let _ = {
 
     /*
   Skip.test "bindThis" (fun _ ->
-    let fn = ((fun a -> string_of_int a) [@bs]) in
+    let fn = ((fun a -> Int.toString a) [@bs]) in
     let boundFn = bindThis fn "this" in
 
     expect (call boundFn () 2) -> toEqual "2"
@@ -205,14 +205,14 @@ let _ = {
 
   describe("fn", _ => {
     test("calls implementation", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
       let fn = MockJs.fn(mockFn)
 
       expect(fn(18))->toBe("18")
     })
 
     test("calls - records call arguments", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
 
       let _ = MockJs.fn(mockFn)(74)
       let _ = MockJs.fn(mockFn)(89435)
@@ -222,7 +222,7 @@ let _ = {
     })
 
     test("mockClear - resets calls", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
 
       let before = mockFn->MockJs.calls
       let _ = (MockJs.fn(mockFn)(1), MockJs.fn(mockFn)(2))
@@ -234,7 +234,7 @@ let _ = {
     })
 
     test("mockReset - resets calls", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
       let fn = MockJs.fn(mockFn)
 
       let before = mockFn->MockJs.calls
@@ -250,7 +250,7 @@ let _ = {
     Skip.test(
       "mockReset - resets implementations - skipped for now as this removes the original implementation too causing an undefnied to be returned",
       _ => {
-        let mockFn = Mock.fn(a => string_of_int(a))
+        let mockFn = Mock.fn(a => Int.toString(a))
         mockFn->MockJs.mockReturnValue("128")->ignore
         let fn = MockJs.fn(mockFn)
 
@@ -263,29 +263,29 @@ let _ = {
     )
 
     test("mockImplementation - sets implementation to use for subsequent invocations", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
       let fn = MockJs.fn(mockFn)
 
       let before = fn(10)
-      mockFn->MockJs.mockImplementation(a => string_of_int(a * 2))->ignore
+      mockFn->MockJs.mockImplementation(a => Int.toString(a * 2))->ignore
 
       expect((before, fn(18), fn(24)))->toEqual(("10", "36", "48"))
     })
 
     test("mockImplementationOnce - queues implementation for one subsequent invocation", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
       let fn = MockJs.fn(mockFn)
 
       let before = fn(10)
-      mockFn->MockJs.mockImplementationOnce(a => string_of_int(a * 3))->ignore
-      mockFn->MockJs.mockImplementationOnce(a => string_of_int(a * 2))->ignore
+      mockFn->MockJs.mockImplementationOnce(a => Int.toString(a * 3))->ignore
+      mockFn->MockJs.mockImplementationOnce(a => Int.toString(a * 2))->ignore
 
       expect((before, fn(18), fn(24), fn(12)))->toEqual(("10", "54", "48", "12"))
     })
 
     /* mockReturnThis doesn't make sense for native functions
   test "mockReturnThis - returns `this` on subsequent invocations" (fun _ ->
-    let mockFn = Mock.fn (fun a -> string_of_int a) in
+    let mockFn = Mock.fn (fun a -> Int.toString a) in
     let this = "this" in
     let fn = bindThis (mockFn -> MockJs.fn) this in
 
@@ -300,7 +300,7 @@ let _ = {
  */
 
     test("mockReturnValue - returns given value on subsequent invocations", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
       let fn = MockJs.fn(mockFn)
 
       let before = fn(10)
@@ -310,7 +310,7 @@ let _ = {
     })
 
     test("mockReturnValueOnce - queues implementation for one subsequent invocation", _ => {
-      let mockFn = Mock.fn(a => string_of_int(a))
+      let mockFn = Mock.fn(a => Int.toString(a))
       let fn = MockJs.fn(mockFn)
 
       let before = fn(10)
@@ -323,7 +323,7 @@ let _ = {
 
   describe("fn2", _ =>
     test("calls implementation", _ => {
-      let mockFn = Mock.fn2((a, b) => string_of_int(a + b))
+      let mockFn = Mock.fn2((a, b) => Int.toString(a + b))
       let fn = MockJs.fn(mockFn)
 
       expect(call2(fn, 18, 24))->toBe("42")
@@ -332,7 +332,7 @@ let _ = {
 
   /*
   test "calls - records call arguments" (fun _ ->
-    let mockFn = Mock.fn2 ((fun a b -> string_of_int (a + b)) [@bs]) in
+    let mockFn = Mock.fn2 ((fun a b -> Int.toString (a + b)) [@bs]) in
 
     let _ = MockJs.fn mockFn 18 24 in
     let calls  = mockFn -> MockJs.calls in

--- a/__tests__/vitest_vitest.res
+++ b/__tests__/vitest_vitest.res
@@ -1,6 +1,6 @@
 open Vitest
 open Expect
-open! Expect.Operators
+// open! Expect.Operators
 module Promise = Js.Promise
 
 @val external setTimeout: (unit => unit, int) => unit = "setTimeout"
@@ -15,7 +15,7 @@ let () = describe("Fake Timers", () => {
     let before = flag.contents
     Vi.runAllTimers()
 
-    expect((before, flag.contents)) == (false, true)
+    expect((before, flag.contents))->toEqual((false, true))
   })
 
   testPromise("runAllTicks", async () => {
@@ -27,7 +27,7 @@ let () = describe("Fake Timers", () => {
 
     await Promise.make(
       (~resolve, ~reject as _) =>
-        nextTick(() => resolve(expect((before, flag.contents)) == (false, true))),
+        nextTick(() => resolve(expect((before, flag.contents))->toEqual((false, true)))),
     )
   })
 
@@ -50,7 +50,7 @@ let () = describe("Fake Timers", () => {
     let inbetween = flag.contents
     Vi.advanceTimersByTime(1000)
 
-    expect((before, inbetween, flag.contents)) == (false, false, true)
+    expect((before, inbetween, flag.contents))->toEqual((false, false, true))
   })
 
   test("advanceTimersByTime", () => {
@@ -62,7 +62,7 @@ let () = describe("Fake Timers", () => {
     let inbetween = flag.contents
     Vi.advanceTimersByTime(1000)
 
-    expect((before, inbetween, flag.contents)) == (false, false, true)
+    expect((before, inbetween, flag.contents))->toEqual((false, false, true))
   })
 
   test("runOnlyPendingTimers", () => {
@@ -78,7 +78,7 @@ let () = describe("Fake Timers", () => {
     let inBetween = count.contents
     Vi.runOnlyPendingTimers()
 
-    expect((before, inBetween, count.contents)) == (1, 2, 3)
+    expect((before, inBetween, count.contents))->toEqual((1, 2, 3))
   })
 
   test("clearAllTimers", () => {
@@ -89,7 +89,7 @@ let () = describe("Fake Timers", () => {
     Vi.clearAllTimers()
     Vi.runAllTimers()
 
-    expect((before, flag.contents)) == (false, false)
+    expect((before, flag.contents))->toEqual((false, false))
   })
 
   testPromise("clearAllTimers", async () => {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "changelog": "yarn auto-changelog -p && git add HISTORY.md",
     "build": "yarn rescript:build",
     "rescript:clean": "yarn rescript clean",
-    "rescript:build": "yarn rescript build -with-deps",
-    "rescript:dev": "yarn rescript build -with-deps -w",
+    "rescript:build": "yarn rescript build",
+    "rescript:build:dev": "yarn rescript build --dev",
+    "rescript:dev": "yarn rescript watch --dev",
     "test": "yarn vitest --run --coverage --allow-only",
     "test:dev": "yarn vitest",
     "yalc:dev": "yarn rescript:dev & yarn nodemon -x \"yalc push\"",
@@ -31,12 +32,16 @@
   "files": [
     "src",
     "lib/bs",
-    "rescript.json"
+    "rescript.json",
+    "__tests__/.gitkeep"
   ],
+  "peerDependencies": {
+    "rescript": "^12.0.0-beta.4"
+  },
   "devDependencies": {
     "auto-changelog": "^2.5.0",
     "nodemon": "^3.1.7",
-    "rescript": "^11.1.0"
+    "rescript": "^12.0.0-beta.4"
   },
   "dependencies": {
     "@vitest/coverage-v8": "^2.1.8",

--- a/rescript.json
+++ b/rescript.json
@@ -1,7 +1,7 @@
 {
   "name": "@greenfinity/rescript-vitest",
   "namespace": false,
-  "bsc-flags": ["-bs-no-version-header", "-bs-super-errors"],
+  "compiler-flags": ["-bs-no-version-header"],
   "suffix": ".bs.mjs",
   "package-specs": {
     "module": "esmodule",
@@ -19,6 +19,5 @@
   "warnings": {
     "number": "-44",
     "error": "+101"
-  },
-  "bs-dependencies": []
+  }
 }

--- a/src/Vitest.res
+++ b/src/Vitest.res
@@ -160,22 +160,24 @@ module Runner = (A: Asserter) => {
       Js.Undefined.fromOption(timeout),
     )
 
-  let testAll = (name, inputs, callback) => List.iter(input => {
+  let testAll = (name, inputs, callback) =>
+    List.forEach(inputs, input => {
       let name = `${name} - ${input->Js.String.make}`
       _test(name, () => {
         affirm(callback(input))
         Js.undefined
       })
-    }, inputs)
+    })
 
-  let testAllPromise = (name: string, inputs, ~timeout=?, callback) => List.iter(input => {
+  let testAllPromise = (name: string, inputs, ~timeout=?, callback) =>
+    List.forEach(inputs, input => {
       let name = `${name} - ${input->Js.String.make}`
       _testPromise(
         name,
         () => then(callback(input), a => a->A.affirm->Promise.resolve),
         Js.Undefined.fromOption(timeout),
       )
-    }, inputs)
+    })
 
   @module("vitest")
   external describe: (string, @uncurry unit => Js.undefined<unit>) => unit = "describe"
@@ -233,22 +235,24 @@ module Runner = (A: Asserter) => {
         Js.Undefined.fromOption(timeout),
       )
 
-    let testAll = (name, inputs, callback) => List.iter(input => {
+    let testAll = (name, inputs, callback) =>
+      List.forEach(inputs, input => {
         let name = `${name} - ${input->Js.String.make}`
         _test(name, () => {
           affirm(callback(input))
           Js.undefined
         })
-      }, inputs)
+      })
 
-    let testAllPromise = (name, inputs, ~timeout=?, callback) => List.iter(input => {
+    let testAllPromise = (name, inputs, ~timeout=?, callback) =>
+      List.forEach(inputs, input => {
         let name = `${name} - ${input->Js.String.make}`
         _testPromise(
           name,
           () => then(callback(input), a => a->A.affirm->Promise.resolve),
           Js.Undefined.fromOption(timeout),
         )
-      }, inputs)
+      })
 
     @module("vitest") @scope("describe")
     external describe: (string, @uncurry unit => Js.undefined<unit>) => unit = "only"
@@ -265,14 +269,16 @@ module Runner = (A: Asserter) => {
     @module("vitest") @scope("it") @module("vitest") @scope("it")
     external testPromise: (string, @uncurry unit => promise<A.t<'a>>) => unit = "skip"
     let testPromise = (name, ~timeout as _=?, callback) => testPromise(name, callback)
-    let testAll = (name, inputs, callback) => List.iter(input => {
+    let testAll = (name, inputs, callback) =>
+      List.forEach(inputs, input => {
         let name = `${name} - ${input->Js.String.make}`
         test(name, () => callback(input))
-      }, inputs)
-    let testAllPromise = (name, inputs, ~timeout as _=?, callback) => List.iter(input => {
+      })
+    let testAllPromise = (name, inputs, ~timeout as _=?, callback) =>
+      List.forEach(inputs, input => {
         let name = `${name} - ${input->Js.String.make}`
         testPromise(name, () => callback(input))
-      }, inputs)
+      })
     @module("vitest") @scope("describe")
     external describe: (string, @uncurry unit => Js.undefined<unit>) => unit = "skip"
     let describe = (label, f) =>
@@ -337,18 +343,18 @@ module Expect = {
   let not_ = (#Just(a)) => #Not(a)
   let not__ = not_ /* For Reason syntax compatibility. TODO: deprecate and remove */
 
-  module Operators = {
-    @@ocaml.text(" experimental ")
+  // module Operators = {
+  //   @@ocaml.text(" experimental ")
 
-    let \"==" = (a, b) => toBe(a, b)
-    let \">" = (a, b) => toBeGreaterThan(a, b)
-    let \">=" = (a, b) => toBeGreaterThanOrEqual(a, b)
-    let \"<" = (a, b) => toBeLessThan(a, b)
-    let \"<=" = (a, b) => toBeLessThanOrEqual(a, b)
-    let \"=" = (a, b) => toEqual(a, b)
-    let \"<>" = (a, b) => a->not_->toEqual(b)
-    let \"!=" = (a, b) => a->not_->toBe(b)
-  }
+  //   let \"==" = (a, b) => toBe(a, b)
+  //   let \">" = (a, b) => toBeGreaterThan(a, b)
+  //   let \">=" = (a, b) => toBeGreaterThanOrEqual(a, b)
+  //   let \"<" = (a, b) => toBeLessThan(a, b)
+  //   let \"<=" = (a, b) => toBeLessThanOrEqual(a, b)
+  //   let \"=" = (a, b) => toEqual(a, b)
+  //   let \"<>" = (a, b) => a->not_->toEqual(b)
+  //   let \"!=" = (a, b) => a->not_->toBe(b)
+  // }
 }
 
 module ExpectJs = {
@@ -389,19 +395,19 @@ module MockJs = {
   external fn: fn<'fn, _, _> => 'fn = "%identity"
   @get @scope("mock") external calls: fn<_, 'args, _> => array<'args> = "calls"
   let calls = self =>
-    Js.Array.copy(calls(self)) /* Awesome, the bloody things are mutated so we need to copy */
+    Array.copy(calls(self)) /* Awesome, the bloody things are mutated so we need to copy */
   let calls = self =>
     Array.map(
+      calls(self),
       %raw(`
     function (args) { return args.length === 1 ? args[0] : args }
   `),
-      calls(self),
     ) /* there's no such thing as aa 1-ary tuple, so we need to unbox single-element arrays */
   @get @scope("mock")
   external instances: fn<_, _, 'ret> => array<'ret> =
     "instances" /* TODO: semms this only records "instances" created by `new` */
   let instances = self =>
-    Js.Array.copy(instances(self)) /* Awesome, the bloody things are mutated so we need to copy */
+    Array.copy(instances(self)) /* Awesome, the bloody things are mutated so we need to copy */
 
   @ocaml.doc(" Beware: this actually replaces `mock`, not just `mock.instances` and `mock.calls` ")
   @send

--- a/src/Vitest.resi
+++ b/src/Vitest.resi
@@ -122,18 +122,18 @@ module Expect: {
   let not_: plainPartial<'a> => invertedPartial<'a>
   let not__: plainPartial<'a> => invertedPartial<'a>
 
-  module Operators: {
-    @@ocaml.text(" experimental ")
+//   module Operators: {
+//     @@ocaml.text(" experimental ")
 
-    let \"==": ([< partial<'a>], 'a) => assertion
-    let \">": ([< partial<'a>], 'a) => assertion
-    let \">=": ([< partial<'a>], 'a) => assertion
-    let \"<": ([< partial<'a>], 'a) => assertion
-    let \"<=": ([< partial<'a>], 'a) => assertion
-    let \"=": ([< partial<'a>], 'a) => assertion
-    let \"<>": (plainPartial<'a>, 'a) => assertion
-    let \"!=": (plainPartial<'a>, 'a) => assertion
-  }
+//     let \"==": ([< partial<'a>], 'a) => assertion
+//     let \">": ([< partial<'a>], 'a) => assertion
+//     let \">=": ([< partial<'a>], 'a) => assertion
+//     let \"<": ([< partial<'a>], 'a) => assertion
+//     let \"<=": ([< partial<'a>], 'a) => assertion
+//     let \"=": ([< partial<'a>], 'a) => assertion
+//     let \"<>": (plainPartial<'a>, 'a) => assertion
+//     let \"!=": (plainPartial<'a>, 'a) => assertion
+//   }
 }
 
 module ExpectJs: {

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -5,7 +5,8 @@ const projectRootPath = path.resolve(".");
 
 export default defineConfig({
   test: {
-    include: ["**/__tests__/**/*_vitest.bs.mjs"],
+    include: ["**/*_vitest.bs.mjs"],
+    exclude: ["**/lib/bs/**/*"],
     globals: true,
     reporters: "verbose",
     environment: "jsdom",

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,8 +226,10 @@ __metadata:
     auto-changelog: "npm:^2.5.0"
     jsdom: "npm:^25.0.1"
     nodemon: "npm:^3.1.7"
-    rescript: "npm:^11.1.0"
+    rescript: "npm:^12.0.0-beta.4"
     vitest: "npm:^2.1.8"
+  peerDependencies:
+    rescript: ^12.0.0-beta.4
   languageName: unknown
   linkType: soft
 
@@ -329,6 +331,41 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
+  languageName: node
+  linkType: hard
+
+"@rescript/darwin-arm64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/darwin-arm64@npm:12.0.0-beta.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rescript/darwin-x64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/darwin-x64@npm:12.0.0-beta.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rescript/linux-arm64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/linux-arm64@npm:12.0.0-beta.4"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rescript/linux-x64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/linux-x64@npm:12.0.0-beta.4"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rescript/win32-x64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/win32-x64@npm:12.0.0-beta.4"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1836,14 +1873,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rescript@npm:^11.1.0":
-  version: 11.1.4
-  resolution: "rescript@npm:11.1.4"
+"rescript@npm:^12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "rescript@npm:12.0.0-beta.4"
+  dependencies:
+    "@rescript/darwin-arm64": "npm:12.0.0-beta.4"
+    "@rescript/darwin-x64": "npm:12.0.0-beta.4"
+    "@rescript/linux-arm64": "npm:12.0.0-beta.4"
+    "@rescript/linux-x64": "npm:12.0.0-beta.4"
+    "@rescript/win32-x64": "npm:12.0.0-beta.4"
+  dependenciesMeta:
+    "@rescript/darwin-arm64":
+      optional: true
+    "@rescript/darwin-x64":
+      optional: true
+    "@rescript/linux-arm64":
+      optional: true
+    "@rescript/linux-x64":
+      optional: true
+    "@rescript/win32-x64":
+      optional: true
   bin:
-    bsc: bsc
-    bstracing: lib/bstracing
-    rescript: rescript
-  checksum: 10/2ba71cf76e04000afb025afc245aef0d4c1647c73323f325bbc386f562df5a9fdddf137f6031ac7bb59c935c60174156d7a605a05a70adac8bd76dc0795aa6bd
+    bsc: cli/bsc.js
+    bstracing: cli/bstracing.js
+    rescript: cli/rescript.js
+    rescript-legacy: cli/rescript-legacy.js
+    rescript-tools: cli/rescript-tools.js
+  checksum: 10/2dbb8cbd28e774e5039d4bc2bb91b523c1fdf4ab5fedafcb8fa1ee3367044fba422ea67707265c01dc6782b86d2a14c63c34a5c5c2eb43bffb5f9f73505955a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- update peer dependency
- deprecate Operators module, experimental support might be reintroduced later
- Update calls to match Core.List, Core.Array
- Update deprecations